### PR TITLE
Fixed MISRA rule 12.7 for GX_FIXED_VAL_... macros

### DIFF
--- a/common/inc/gx_api.h
+++ b/common/inc/gx_api.h
@@ -2903,14 +2903,14 @@ typedef struct GX_FIXED_POINT_STRUCT
 #define GX_FIXED_VAL_ONE           1024
 #define GX_FIXED_VAL_FRACTION_MASK 0x3ff
 
-#define GX_FIXED_VAL_MAKE(_a)      (((int)_a) << GX_FIXED_VAL_SHIFT)
-#define GX_FIXED_VAL_TO_INT(_a)    ((int)(((int)_a) >> GX_FIXED_VAL_SHIFT))
-#define GX_FIXED_VAL_MUL(_a, _b)   ((((int)_a) * (_b)) >> GX_FIXED_VAL_SHIFT)
-#define GX_FIXED_VAL_DIV(_a, _b)   ((((int)_a) << GX_FIXED_VAL_SHIFT) / ((int)_b))
-#define GX_FIXED_VAL_RND(_a)       (GX_VALUE)((((GX_FIXED_VAL)_a) + GX_FIXED_VAL_HALF) >> GX_FIXED_VAL_SHIFT)
-#define GX_FIXED_VAL_RND_UP(_a)    ((((GX_FIXED_VAL)_a) + GX_FIXED_VAL_ONE - 1) >> GX_FIXED_VAL_SHIFT)
-#define GX_FIXED_VAL_ADD_ONE(_a)   (((int)_a) + GX_FIXED_VAL_ONE)
-#define GX_FIXED_VAL_SUB_ONE(_a)   (((int)_a) - GX_FIXED_VAL_ONE)
+#define GX_FIXED_VAL_MAKE(_a)      (((int)(_a)) * GX_FIXED_VAL_ONE)
+#define GX_FIXED_VAL_TO_INT(_a)    ((int)(((int)(_a)) / GX_FIXED_VAL_ONE))
+#define GX_FIXED_VAL_MUL(_a, _b)   ((((int)(_a)) * (_b)) / GX_FIXED_VAL_ONE)
+#define GX_FIXED_VAL_DIV(_a, _b)   ((((int)(_a)) * GX_FIXED_VAL_ONE) / ((int)(_b)))
+#define GX_FIXED_VAL_RND(_a)       (GX_VALUE)((((GX_FIXED_VAL)(_a)) + GX_FIXED_VAL_HALF) / GX_FIXED_VAL_ONE)
+#define GX_FIXED_VAL_RND_UP(_a)    ((((GX_FIXED_VAL)(_a)) + GX_FIXED_VAL_ONE - 1) / GX_FIXED_VAL_ONE)
+#define GX_FIXED_VAL_ADD_ONE(_a)   (((int)(_a)) + GX_FIXED_VAL_ONE)
+#define GX_FIXED_VAL_SUB_ONE(_a)   (((int)(_a)) - GX_FIXED_VAL_ONE)
 
 /* Define the system API mappings based on the error checking
    selected by the user.  Note: this section is only applicable to


### PR DESCRIPTION
Fixed MISRA rule 12.7 violation on GX_FIXED_VAL_... macros by replacing shift operations on signed operands with mul/div operations.
On these lines also rule 19.10 got addressed.

Luckily this fix was relatively easy because GX_FIXED_VAL_SHIFT and GX_FIXED_VAL_ONE are both available and match.

I did not check all occurrences of GX_FIXED_VAL_SHIFT.
If this PR is not covering everything please feel free to change it, extend it or convert it in a feature request. 😉 I hope this helps.